### PR TITLE
Feature/acknowledge

### DIFF
--- a/elhub_sdk/acknolwedgment.py
+++ b/elhub_sdk/acknolwedgment.py
@@ -1,0 +1,109 @@
+"""
+Acknowledgement related functions
+
+
+After the market party has persisted the received messages,
+an Acknowledgement message referring to the polled data set
+must be sent back to Elhub on the polling service to confirm
+that the messages has been received.
+
+Note: Elhub will send a 200 response regardless of the validity of the
+Original Business Document Reference. To confirm that the
+acknowlegment was sucessfull poll again and check if the
+request have been acknowledged.
+
+"""
+import logging
+import uuid
+from datetime import datetime
+
+import zeep
+from zeep.plugins import HistoryPlugin
+
+from elhub_sdk.constants import ELHUB_GSN, TIME_FORMAT
+from elhub_sdk.enums import (
+    BSR_IDS,
+    DOCUMENT_TYPE_UN_CEFACT,
+    LIST_AGENCY_IDENTIFIER,
+    ROLES,
+    SCHEME_AGENCY_IDENTIFIER,
+    STATUS_TYPE,
+)
+
+logger = logging.getLogger()
+
+
+def acknowledge_poll(
+    client: zeep.Client,
+    history: HistoryPlugin,
+    sender_gsn: str,
+    original_business_document_reference: str,
+    process_role: ROLES = ROLES.THIRD_PARTY,
+) -> bool:
+    """
+    Metering Values | Market processes WSDL
+    Args:
+        history:
+        client:
+        meter_identificator:
+        sender_gsn:
+        original_business_document_reference:
+        process_role:
+
+    Returns:
+
+    """
+
+    factory = client.type_factory('ns4')
+    eh_request = factory.Acknowledgement(
+        Header={
+            'Identification': uuid.uuid4(),
+            'DocumentType': {
+                '_value_1': DOCUMENT_TYPE_UN_CEFACT.QUERY.value,
+                'listAgencyIdentifier': LIST_AGENCY_IDENTIFIER.UN_CEFACT.value,
+            },
+            'Creation': f'{datetime.utcnow().strftime(TIME_FORMAT)}',
+            'PhysicalSenderEnergyParty': {
+                'Identification': {
+                    '_value_1': sender_gsn,
+                    'schemeAgencyIdentifier': SCHEME_AGENCY_IDENTIFIER.GS1.value,
+                }
+            },
+            'JuridicalSenderEnergyParty': {
+                'Identification': {
+                    '_value_1': sender_gsn,
+                    'schemeAgencyIdentifier': SCHEME_AGENCY_IDENTIFIER.GS1.value,
+                }
+            },
+            'JuridicalRecipientEnergyParty': {
+                'Identification': {'_value_1': ELHUB_GSN, 'schemeAgencyIdentifier': SCHEME_AGENCY_IDENTIFIER.GS1.value}
+            },
+        },
+        ProcessEnergyContext={  # https://dok.elhub.no/ediel2/general#General-Process
+            'EnergyBusinessProcess': {
+                '_value_1': BSR_IDS.METERING_VALUES.value,
+                'listAgencyIdentifier': LIST_AGENCY_IDENTIFIER.ELHUB.value,
+            },
+            'EnergyBusinessProcessRole': {
+                '_value_1': process_role.value,
+                'listAgencyIdentifier': LIST_AGENCY_IDENTIFIER.UN_CEFACT.value,
+            },
+            'EnergyIndustryClassification': "23",
+        },
+        PayloadResponseEvent={
+            'StatusType': {
+                '_value_1': STATUS_TYPE.ACCEPTED.value,
+                'listAgencyIdentifier': LIST_AGENCY_IDENTIFIER.UN_CEFACT.value,
+            },
+            'OriginalBusinessDocumentReference': original_business_document_reference,
+        },
+    )
+
+    try:
+        response = client.service.Acknowledge(eh_request)
+        if history.last_received:
+            return True
+        logger.error(f"Unknown error: {response}")
+    except Exception as ex:
+        logger.exception(ex)
+    return False

--- a/elhub_sdk/enums.py
+++ b/elhub_sdk/enums.py
@@ -88,3 +88,11 @@ class THIRD_PARTY_ACTION(Enum):
     ADD = "Add"
     DELETE = "Delete"
     UPDATE = "Update"
+
+class STATUS_TYPE(Enum):
+    """
+    Status Type
+    """
+
+    ACCEPTED = '39'
+    REJECTED = '41'

--- a/elhub_sdk/enums.py
+++ b/elhub_sdk/enums.py
@@ -89,9 +89,12 @@ class THIRD_PARTY_ACTION(Enum):
     DELETE = "Delete"
     UPDATE = "Update"
 
+
+
 class STATUS_TYPE(Enum):
     """
     Status Type
+    ref: https://dok.elhub.no/ediel2/acknowledgement
     """
 
     ACCEPTED = '39'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,6 +6,7 @@ import pytest
 from elhub_sdk.client import APIClient, ElHubEnvironment, ElHubService
 from elhub_sdk.consumption import poll_consumption, request_consumption
 from elhub_sdk.enrollment import get_meter_characteristics
+from elhub_sdk.acknolwedgment import acknowledge_poll
 from elhub_sdk.enums import THIRD_PARTY_ACTION
 from elhub_sdk.settings import CERT_FILE, KEY_FILE
 from elhub_sdk.third_party import request_action
@@ -114,5 +115,31 @@ def test_request_consumption():
 
     response = request_consumption(
         client, history, meter_identificator, sender_gsn=THIRD_PARTY_GSN_EXA, start=start, end=end
+    )
+    assert response != False
+
+
+@pytest.mark.integrationtest
+def test_acknowledge_poll_metering_values():
+    """
+    Acknowledging Poll for metering values for given Original Business Document Reference
+    Returns:
+
+    """
+
+    original_business_document_reference = "66666666-ab50-4d9a-95bf-ae3964f8ea96"
+
+    client, history = APIClient.get_client(
+        environment=ElHubEnvironment.TEST,
+        service=ElHubService.METERING_VALUES,
+        key_file=KEY_FILE,
+        cert_file=CERT_FILE,
+    )
+
+    response = acknowledge_poll(
+        client,
+        history,
+        sender_gsn=THIRD_PARTY_GSN_EXA,
+        original_business_document_reference=original_business_document_reference,
     )
     assert response != False

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -143,3 +143,29 @@ def test_acknowledge_poll_metering_values():
         original_business_document_reference=original_business_document_reference,
     )
     assert response != False
+
+
+@pytest.mark.integrationtest
+def test_acknowledge_poll_market_processes():
+    """
+    Acknowledging Poll for metering values for given Original Business Document Reference
+    Returns:
+
+    """
+
+    original_business_document_reference = "66666666-ab50-4d9a-95bf-ae3964f8ea96"
+
+    client, history = APIClient.get_client(
+        environment=ElHubEnvironment.TEST,
+        service=ElHubService.MARKET_PROCESSES,
+        key_file=KEY_FILE,
+        cert_file=CERT_FILE,
+    )
+
+    response = acknowledge_poll(
+        client,
+        history,
+        sender_gsn=THIRD_PARTY_GSN_EXA,
+        original_business_document_reference=original_business_document_reference,
+    )
+    assert response != False


### PR DESCRIPTION
Implements new feature to acknowledge polls for metering values and market processes

- Adds Status Type in enums
- Adds acknowledgement.py
- Adds tests for acknowledging metering values & market processes

Note: Elhub will send a 200 response regardless of the validity of the Original Business Document Reference. To confirm that the acknowlegment was sucessfull the user should verify in the next poll the requests have been acknowledged.

Related issue: None
Elhub reference: https://dok.elhub.no/ediel2/acknowledgement